### PR TITLE
Changed casing of BLAS. Included LDFLAGS to $(examples)

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -32,15 +32,15 @@ TARGET = $(patsubst %,%.o,$(examples))
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(examples): % : %.o
-	$(LDC) -o $@ $(patsubst %,%.o,$@) -lbinned -lbinnedBLAS -lreproBLAS
+	$(LDC) -o $@ $(patsubst %,%.o,$@) $(LDFLAGS) -lbinned -lbinnedblas -lreproblas
 
 $(omp_examples): % : %.o
 	$(CC) $(CFLAGS) $(OMP_FLAG) -c $(patsubst %,%.c,$@)
-	$(LDC) $(OMP_FLAG) -o run-$@ $(patsubst %,%.o,$@) $(LDFLAGS) -lbinned -lbinnedBLAS -lreproBLAS
+	$(LDC) $(OMP_FLAG) -o run-$@ $(patsubst %,%.o,$@) $(LDFLAGS) -lbinned -lbinnedblas -lreproblas
 
 $(mpi_examples): % : %.o
 	$(MPICC) $(CFLAGS) $(INCR) -c $(patsubst %,%.c,$@)
-	$(MPILDC) -o $@ $(patsubst %,%.o,$@) $(LDFLAGS) -lbinned -lbinnedBLAS -lreproBLAS -lbinnedMPI
+	$(MPILDC) -o $@ $(patsubst %,%.o,$@) $(LDFLAGS) -lbinned -lbinnedblas -lreproblas -lbinnedMPI
 
 clean:
 	rm -rf *.o


### PR DESCRIPTION
Had some trouble compiling the examples and realized that the upper casing of -lbinnedBLAS and -lreproBLAS was causing an error. Need to verify for -lbinnedMPI.